### PR TITLE
Add `MIGRATION.md` migration guide

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -10,8 +10,8 @@
 In case of passing false as parameter or not providing a value (false being the default for this ConfigItem), you'll have to ensure that:
   - `download_metadata.swift` isn't being used; if it is, it's a good time to migrate to the new tooling
   - You're not relying on `ios_bump_version_release` for commiting the `.po/.pot` file
-- The deprecated actions `ios_localize_project` and `ios_update_metadata` were now completely removed. If your project is still using it, please use the new tooling instead.
-See `ios_generate_strings_file_from_code`, `ios_extract_keys_from_strings_files`, `ios_download_strings_files_from_glotpress` and `ios_merge_strings_files`.
+- The deprecated actions `ios_localize_project` and `ios_update_metadata` were now completely removed. If your project is still using them, please use the new tooling instead.
+  - See `ios_generate_strings_file_from_code`, `ios_extract_keys_from_strings_files`, `ios_download_strings_files_from_glotpress` and `ios_merge_strings_files` for typical replacements.
 
 ### Clean-ups
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,18 @@
+# Release Toolkit Migration Guide
+
+---
+
+## Migrating to Trunk
+
+### Considerations for breaking changes
+
+- Ensure that calls to `ios_bump_version_release` already passed `skip_glotpress: true`.
+In case of passing false as parameter or not providing a value (false being the default for this ConfigItem), you'll have to ensure that:
+  - `download_metadata.swift` isn't being used; if it is, it's a good time to migrate to the new tooling
+  - You're not relying on `ios_bump_version_release` for commiting the `.po/.pot` file
+- The deprecated actions `ios_localize_project` and `ios_update_metadata` were now completely removed. If your project is still using it, please use the new tooling instead.
+See `ios_generate_strings_file_from_code`, `ios_extract_keys_from_strings_files`, `ios_download_strings_files_from_glotpress` and `ios_merge_strings_files`.
+
+### Clean-ups
+
+- You can now delete the `ENV['APP_STORE_STRINGS_FILE_NAME']` from your Fastfile, as it isn't being used anymore.


### PR DESCRIPTION
**EDIT**: This PR has been re-created in the main repo as https://github.com/wordpress-mobile/release-toolkit/pull/452

## What does it do?
This PR proposes the usage of a migration guide, `MIGRATION.md`.
The idea is that a guide like this can be specially useful to provide more context for a successful migration between major releases of the `release-toolkit`, giving more information about deprecations, clean-ups that the clients can do, how to deal with breaking changes and any other adaptations that the hosting projects need to do when migrating to a new version.

A process to update the `MIGRATION.md` file can be very similar to the one followed by `CHANGELOG.md`: PRs containing changes that would require attention during a migration can highlight them in the appropriate subsection of the `## Migrating to Trunk` section. Once the new major version is released, `## Migrating to Trunk` can be changed to `## Migrating to 7.0.0`, for example.
I've initially organised the migration topics into two main subsections, `Considerations for breaking changes` and `Clean-ups`, which I believe will be common cases; more subsections can be added or a different grouping can be done as we see fit.

[This](https://github.com/wordpress-mobile/release-toolkit/pull/447#discussion_r1092386301) is the discussion with @AliSoftware that originated this PR.

## Related PRs
- This PR builds on top of https://github.com/wordpress-mobile/release-toolkit/pull/447, given it refers to a few changes performed there.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the approprioate existing `###` subsection of the existing `## Trunk` section.